### PR TITLE
feat: 일반 로그인 성공, reissue, 소셜 로그인 시 응답 형태 수정

### DIFF
--- a/src/main/java/com/sweetbalance/backend/controller/ReissueController.java
+++ b/src/main/java/com/sweetbalance/backend/controller/ReissueController.java
@@ -1,6 +1,8 @@
 package com.sweetbalance.backend.controller;
 
 import com.sweetbalance.backend.dto.DefaultResponseDTO;
+import com.sweetbalance.backend.dto.response.TokenPairDTO;
+import com.sweetbalance.backend.util.InnerFilterResponseSender;
 import com.sweetbalance.backend.util.JWTUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -99,11 +101,13 @@ public class ReissueController {
         }
         jwtUtil.deleteRefreshEntity(refresh);
 
-        response.setHeader("Authorization", "Bearer " + newAccessToken);
-        response.addCookie(createCookie("refresh", newRefreshToken));
+        // 프론트 HTTPS 배포 이전 까지는 쿠키 방식 응답 미사용
+//        response.setHeader("Authorization", "Bearer " + newAccessToken);
+//        response.addCookie(createCookie("refresh", newRefreshToken));
 
+        TokenPairDTO tokens = new TokenPairDTO(newAccessToken, newRefreshToken);
         return ResponseEntity.status(200).body(
-                DefaultResponseDTO.success("토큰 재발급 성공", null)
+                DefaultResponseDTO.success("토큰 재발급 성공", tokens)
         );
     }
 

--- a/src/main/java/com/sweetbalance/backend/util/filter/LoginFilter.java
+++ b/src/main/java/com/sweetbalance/backend/util/filter/LoginFilter.java
@@ -2,6 +2,7 @@ package com.sweetbalance.backend.util.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sweetbalance.backend.dto.identity.CustomUserDetails;
+import com.sweetbalance.backend.dto.response.TokenPairDTO;
 import com.sweetbalance.backend.util.InnerFilterResponseSender;
 import com.sweetbalance.backend.util.JWTUtil;
 import jakarta.servlet.FilterChain;
@@ -74,12 +75,13 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String accessToken = jwtUtil.generateBasicAccessToken(userId, username, role);
         String refreshToken = jwtUtil.generateBasicRefreshToken(userId, username, role);
 
-        //응답 설정
-        response.setHeader("Authorization", "Bearer " + accessToken);
-        response.addCookie(createCookie("refresh", refreshToken));
+        // 프론트 HTTPS 배포 이전 까지는 쿠키 방식 응답 미사용
+//        response.setHeader("Authorization", "Bearer " + accessToken);
+//        response.addCookie(createCookie("refresh", refreshToken));
 
+        TokenPairDTO tokens = new TokenPairDTO(accessToken, refreshToken);
         InnerFilterResponseSender.sendInnerResponse(response, 200, 0,
-                "로그인 성공, 토큰 발급 성공", null);
+                "로그인 성공, 토큰 발급 성공", tokens);
     }
 
     //로그인 실패시 실행하는 메소드

--- a/src/main/java/com/sweetbalance/backend/util/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/sweetbalance/backend/util/handler/CustomSuccessHandler.java
@@ -42,8 +42,9 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         String refreshToken = jwtUtil.generateSocialRefreshToken(userId, username, role);
 
-        //refresh 토큰 발급을 통해 클라이언트가 reissue 할 수 있도록 함
-        response.addCookie(createCookie("refresh", refreshToken));
+        // refresh 토큰 발급을 통해 클라이언트가 reissue 할 수 있도록 함
+        // 프론트 HTTPS 배포 이전 까지는 쿠키 방식 응답 미사용
+//        response.addCookie(createCookie("refresh", refreshToken));
         response.sendRedirect("http://localhost:5173/?refresh="+refreshToken);    // 프론트 측 특정 URL
     }
 


### PR DESCRIPTION
feat: 일반 로그인 성공, reissue, 소셜 로그인 시 쿠키 방식 응답 대신 
response body 와 query parameter 를 통한 토큰 응답으로 수정

프론트 측 HTTPS 배포 시 쿠키 방식으로 재설정 가능