### PR TITLE
[CHORE/#32] 리스트, 기록 조회 GET API 수정

### DIFF
--- a/src/main/java/com/sweetbalance/backend/controller/UserController.java
+++ b/src/main/java/com/sweetbalance/backend/controller/UserController.java
@@ -9,6 +9,7 @@ import com.sweetbalance.backend.entity.Beverage;
 import com.sweetbalance.backend.entity.BeverageLog;
 import com.sweetbalance.backend.entity.BeverageSize;
 import com.sweetbalance.backend.entity.User;
+import com.sweetbalance.backend.enums.user.Gender;
 import com.sweetbalance.backend.service.BeverageService;
 import com.sweetbalance.backend.service.BeverageSizeService;
 import com.sweetbalance.backend.service.UserService;
@@ -186,6 +187,8 @@ public class UserController {
             );
         }
 
+        User user = userOptional.get();
+
         List<BeverageLog> dailyBeverageLogs = userService.findTodayBeverageLogsByUserId(userId);
 
         double initSugarSum = 0.0;
@@ -199,8 +202,16 @@ public class UserController {
 
         int unreadAlarmCount = userService.getNumberOfUnreadLogWithinAWeek();
 
+        int additionalSugar = 0;
+        if (user.getGender() == Gender.MALE) {
+            additionalSugar = 25 - totalSugar;
+        } else if (user.getGender() == Gender.FEMALE) {
+            additionalSugar = 20 - totalSugar;
+        }
+
         DailyConsumeInfoDTO dailyConsumeInfo = DailyConsumeInfoDTO.builder()
                 .totalSugar(totalSugar)
+                .additionalSugar(additionalSugar)
                 .beverageCount(beverageCount)
                 .unreadAlarmCount(unreadAlarmCount)
                 .build();

--- a/src/main/java/com/sweetbalance/backend/dto/response/DailyConsumeBeverageListDTO.java
+++ b/src/main/java/com/sweetbalance/backend/dto/response/DailyConsumeBeverageListDTO.java
@@ -13,7 +13,10 @@ import java.util.Locale;
 @Getter @Setter @Builder
 public class DailyConsumeBeverageListDTO {
 
+    private Long beverageLogId;
+    private Long beverageSizeId;
     private String createdAt;
+    private String brand;
     private String beverageName;
     private String imgUrl;
     private int sugar;
@@ -35,7 +38,10 @@ public class DailyConsumeBeverageListDTO {
         int roundedSugar = (int) Math.round(rawSugar);
 
         return DailyConsumeBeverageListDTO.builder()
+                .beverageLogId(log.getLogId())
+                .beverageSizeId(beverageSize.getId())
                 .createdAt(formattedDateTime)
+                .brand(beverage.getBrand())
                 .beverageName(beverage.getName())
                 .imgUrl(beverage.getImgUrl())
                 .sugar(roundedSugar)

--- a/src/main/java/com/sweetbalance/backend/dto/response/DailyConsumeInfoDTO.java
+++ b/src/main/java/com/sweetbalance/backend/dto/response/DailyConsumeInfoDTO.java
@@ -7,6 +7,7 @@ import lombok.*;
 @Getter @Setter @Builder
 public class DailyConsumeInfoDTO {
     private int totalSugar;
+    private int additionalSugar;
     private int beverageCount;
     private int unreadAlarmCount;
 }

--- a/src/main/java/com/sweetbalance/backend/repository/BeverageLogRepository.java
+++ b/src/main/java/com/sweetbalance/backend/repository/BeverageLogRepository.java
@@ -17,6 +17,6 @@ public interface BeverageLogRepository extends JpaRepository<BeverageLog,Long> {
     List<BeverageLog> findAllByUserUserIdAndStatusAndCreatedAtBetween(Long userId, Status status, LocalDateTime start, LocalDateTime end);
     List<BeverageLog> findByUser_UserIdAndCreatedAtBetween(Long userId, LocalDateTime startDateTime, LocalDateTime endDateTime);
     List<BeverageLog> findByUser_UserIdAndCreatedAtBetweenAndStatus(Long userId, LocalDateTime startDateTime, LocalDateTime endDateTime, Status status);
-    List<BeverageLog> findTotalByUserUserId(Long userId, Pageable pageable);
+    List<BeverageLog> findTotalByUserUserIdAndStatus(Long userId, Pageable pageable, Status status);
     List<BeverageLog> findByCreatedAtAfterAndReadByUserFalse(LocalDateTime dateTime);
 }

--- a/src/main/java/com/sweetbalance/backend/service/UserServiceImpl.java
+++ b/src/main/java/com/sweetbalance/backend/service/UserServiceImpl.java
@@ -439,7 +439,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public List<BeverageLog> findTotalBeverageLogsByUserId(Long userId, Pageable pageable) {
-        return beverageLogRepository.findTotalByUserUserId(userId, pageable);
+        return beverageLogRepository.findTotalByUserUserIdAndStatus(userId, pageable, Status.ACTIVE);
     }
 
     @Override

--- a/src/main/java/com/sweetbalance/backend/service/UserServiceImpl.java
+++ b/src/main/java/com/sweetbalance/backend/service/UserServiceImpl.java
@@ -432,8 +432,8 @@ public class UserServiceImpl implements UserService {
         LocalDateTime endOfToday = today.plusDays(1).atStartOfDay().minusNanos(1);
 
         //findAllByUserUserIdAndCreatedAtBetween
-        return beverageLogRepository.findByUser_UserIdAndCreatedAtBetween(
-                userId, startOfToday, endOfToday
+        return beverageLogRepository.findByUser_UserIdAndCreatedAtBetweenAndStatus(
+                userId, startOfToday, endOfToday, Status.ACTIVE
         );
     }
 


### PR DESCRIPTION
## Related Issue 🛠️
- closed #32

## Work Description 📝
- 오늘 섭취 음료수 리스트 조회 API 응답 수정 (브랜드 추가)
- 전체 섭취기록, 오늘 섭취 음료수 리스트 조회에 beverageLogId 추가
- 음료 기록의 deleted status 반영 로직 수정
- 오늘 영양섭취 조회 - 섭취 가능한 당 데이터 추가 (프론트 측 요청사항)

## To Reviewers 💬
프론트 측의 요청사항들이 포함된 내용이어서, 바로 머지하겠습니다!