### PR TITLE
[Feat/#37] : 조건별 음료 리스트 조회 API에서 요청 파라미터 category "전체"인 경우 추가

### DIFF
--- a/src/main/java/com/sweetbalance/backend/service/BeverageServiceImpl.java
+++ b/src/main/java/com/sweetbalance/backend/service/BeverageServiceImpl.java
@@ -148,7 +148,7 @@ public class BeverageServiceImpl implements BeverageService {
             if (StringUtils.hasText(brand)) {
                 predicates.add(cb.equal(root.get("brand"), brand));
             }
-            if (StringUtils.hasText(category)) {
+            if (StringUtils.hasText(category) && !"전체".equals(category)) {
                 predicates.add(cb.equal(root.get("category"),
                         BeverageCategory.valueOf(category)));
             }


### PR DESCRIPTION
조건별 음료 리스트 조회 API에서 요청 파라미터에 category 값이 "전체"로 전달될 시 모든 카테고리에 대해 리스트를 반환하도록 로직 추가