### PR TITLE
[Feat/#37] 관계형 DB에서 Redis를 통해 리프레시 토큰 저장소를 사용하도록 Bean 설정 변경

### DIFF
--- a/src/main/java/com/sweetbalance/backend/repository/refresh/RedisRefreshTokenRepository.java
+++ b/src/main/java/com/sweetbalance/backend/repository/refresh/RedisRefreshTokenRepository.java
@@ -8,6 +8,8 @@ import org.springframework.context.annotation.Primary;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
+@Repository
+@Primary
 public class RedisRefreshTokenRepository implements RefreshTokenRepository {
     private final RedisTemplate<String, Object> redisTemplate;
     private static final String KEY_PREFIX = "refresh_token:";

--- a/src/main/java/com/sweetbalance/backend/repository/refresh/RelationalRefreshTokenRepository.java
+++ b/src/main/java/com/sweetbalance/backend/repository/refresh/RelationalRefreshTokenRepository.java
@@ -5,8 +5,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import org.springframework.context.annotation.Primary;
 
-@Repository
-@Primary
 public class RelationalRefreshTokenRepository implements RefreshTokenRepository {
 
     private final JpaRefreshTokenRepository jpaRefreshTokenRepository;

--- a/src/main/java/com/sweetbalance/backend/util/JWTUtil.java
+++ b/src/main/java/com/sweetbalance/backend/util/JWTUtil.java
@@ -19,10 +19,8 @@ public class JWTUtil {
     private SecretKey secretKey;
     private final RefreshTokenRepository refreshTokenRepository;
 
-    private final long accessTokenExpirationMs = 1000L * 60 * 15; // 15 minutes
-//    private final long accessTokenExpirationMs = 3600000L; // 1 hour
-//    private final long accessTokenExpirationMs = 3600000L * 24 * 90; // 90 days
-    private final long refreshTokenExpirationMs = 3600000L * 24 * 30; // 30 days
+    private final long accessTokenExpirationMs = 1000L * 60 * 30; // 30 minutes
+    private final long refreshTokenExpirationMs = 3600000L * 24 * 14; // 14 days
 
     @Autowired
     public JWTUtil(@Value("${spring.jwt.secret}")String secret, RefreshTokenRepository refreshTokenRepository) {


### PR DESCRIPTION
[Feat/#37] 관계형 DB에서 Redis를 통해 리프레시 토큰 저장소를 사용하도록 Bean 설정 변경